### PR TITLE
feat(HU3): funcionalidad para registrar nuevos grupos de estudiantes

### DIFF
--- a/Readme_Guia_Inicio_New_Integrante.md
+++ b/Readme_Guia_Inicio_New_Integrante.md
@@ -21,6 +21,16 @@ Esta guía te ayudará a configurar tu entorno de trabajo y a obtener el código
     
 **Comandos de instalación (si son necesarios)**
 * Para instalar **Git**: `sudo apt update && sudo apt install git`
+* Para instalar **Ubuntu** `wsl --install -d Ubuntu`
+* Para instalar **Docker Desktop en Windows**
+  - Ve a la página oficial: Docker Desktop Windows.
+  - Descarga e instala la versión para Windows 10/11.
+  - Durante la instalación, asegúrate de habilitar WSL2 backend.
+  - Reinicia tu laptop.
+  - Abre Docker Desktop → en Settings revisa que “Use the WSL2 based engine” esté activado.
+  - Desde Ubuntu Terminal (WSL2), prueba:
+    * docker --version
+    * docker run hello-world
 * Para instalar **Docker**: `sudo apt update && sudo apt install docker.io`
 * Para instalar **Docker Compose**: Sigue las instrucciones oficiales de la documentación de Docker para tu sistema operativo, ya que su instalación puede variar.
 * Para instalar **PHP**: `sudo apt update && sudo apt install php8.3-fpm`

--- a/modules/grupos/README_HU3_registrar_grupos.md
+++ b/modules/grupos/README_HU3_registrar_grupos.md
@@ -1,0 +1,50 @@
+\# HU3 — Registrar nuevos grupos de estudiantes
+
+
+
+\## Objetivo
+
+Permitir al coordinador registrar un nuevo grupo con nombre, nivel, número de estudiantes y características.
+
+
+
+\## Criterios de aceptación
+
+\- Se puede crear un grupo con campos requeridos: nombre, nivel, num\_estudiantes (>0).
+
+\- Validar duplicados por (nombre + nivel).
+
+\- Persistencia en BD (tabla `grupo`).
+
+\- Mensajes claros de éxito/error.
+
+
+
+\## Endpoints (propuestos)
+
+\- POST /api/grupos
+
+&nbsp; - body: { nombre, nivel, num\_estudiantes, caracteristicas? }
+
+
+
+\## Modelo (propuesto)
+
+\- grupo(id, nombre, nivel, num\_estudiantes, caracteristicas, activo)
+
+
+
+\## Tareas técnicas
+
+\- \[ ] DTO + validaciones
+
+\- \[ ] Servicio de creación
+
+\- \[ ] Repositorio (INSERT)
+
+\- \[ ] Handler/Controller
+
+\- \[ ] Pruebas (mínimo 3)
+
+
+


### PR DESCRIPTION
#  Historia de Usuario 3 — Registrar nuevos grupos de estudiantes

##  Descripción
Implementación inicial de la HU3 que permite al coordinador registrar nuevos grupos de estudiantes con la información requerida:
- Nombre del grupo
- Nivel académico
- Número de estudiantes
- Características especiales

##  Cambios incluidos
- Carpeta `modules/grupos/`
- Archivo `README_HU3_registrar_grupos.md` con criterios y estructura del módulo.

##  Objetivo
Iniciar el desarrollo del módulo de gestión de grupos, asegurando la estructura base para las próximas integraciones.

---
 Autor: **Johan021222**
